### PR TITLE
Fixed the .docx file ATS analyzer error

### DIFF
--- a/app/api/ats/upload/route.jsx
+++ b/app/api/ats/upload/route.jsx
@@ -16,7 +16,7 @@ export async function POST(request) {
     let resumeText = '';
 
     if (fileType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
-      const result = await mammoth.extractRawText({ arrayBuffer: fileBuffer });
+      const result = await mammoth.extractRawText({ buffer: Buffer.from(fileBuffer) });
       resumeText = result.value;
     } else if (fileType === 'application/pdf') {
       const data = await extract(Buffer.from(fileBuffer));

--- a/app/api/resume/upload/route.jsx
+++ b/app/api/resume/upload/route.jsx
@@ -18,7 +18,7 @@ export async function POST(request) {
     let resumeText = '';
 
     if (fileType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
-      const result = await mammoth.extractRawText({ arrayBuffer: fileBuffer });
+      const result = await mammoth.extractRawText({ buffer: Buffer.from(fileBuffer) });
       resumeText = result.value;
     } else if (fileType === 'application/pdf') {
       const data = await extract(Buffer.from(fileBuffer));


### PR DESCRIPTION
### **Fixes**

- Convert the ArrayBuffer to a Node.js Buffer using Buffer.from(fileBuffer).
- Pass it to mammoth.extractRawText as the buffer property.