### PR TITLE
Fix: Route Google Models to Google AI SDK (Resolves 404 Error)

### DIFF
--- a/app/api/ai-model/route.jsx
+++ b/app/api/ai-model/route.jsx
@@ -1,40 +1,57 @@
 import { QUESTIONS_PROMPT } from "@/services/Constants";
 import { NextResponse } from "next/server";
 import OpenAI from "openai";
+import { GoogleGenerativeAI } from "@google/generative-ai";
 
-export async function POST(req){
-
-  const {jobPosition, jobDescription, duration, type} = await req.json();
-  const FINAL_PROMPT = QUESTIONS_PROMPT
-  .replace('{{jobTitle}}',jobPosition)
-  .replace('{{jobDescription}}', jobDescription)
-  .replace('{{duration}}',duration)
-  .replace('{{type}}',type)
-  console.log(FINAL_PROMPT)
-  try {
-
-  
-    const openai = new OpenAI({
+const openai = new OpenAI({
   baseURL: "https://openrouter.ai/api/v1",
   apiKey: process.env.OPEN_ROUTER_KEY,
-})
+});
 
- const completion = await openai.chat.completions.create({
-    model: "google/gemini-pro-1.5",
-    messages: [
-      { role: "user", content: FINAL_PROMPT }
-    ],
-    max_tokens: 1000,
- 
-  })
-  console.log(completion.choices[0].message)
-  return NextResponse.json(completion.choices[0].message)
+const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
 
+export async function POST(req) {
+  const { jobPosition, jobDescription, duration, type, model } = await req.json();
+
+  const FINAL_PROMPT = QUESTIONS_PROMPT
+    .replace("{{jobTitle}}", jobPosition)
+    .replace("{{jobDescription}}", jobDescription)
+    .replace("{{duration}}", duration)
+    .replace("{{type}}", type);
+
+  console.log("Prompt:", FINAL_PROMPT);
+
+  try {
+    let completion;
+
+    if (model.startsWith("google/")) {
+      const baseGeminiModelName = model.split("/")[1]; 
+      const geminiModel = genAI.getGenerativeModel({ model: baseGeminiModelName });
+      
+      const result = await geminiModel.generateContent(FINAL_PROMPT);
+      const response = await result.response;
+      completion = response.text;
+      
+      if (typeof completion !== 'string' || completion.trim() === "") {
+           throw new Error("Failed to get text content from Google Generative AI response.");
+      }
+
+    } else {
+      const chatCompletion = await openai.chat.completions.create({
+        model: model,
+        messages: [{ role: "user", content: FINAL_PROMPT }],
+        max_tokens: 1000,
+      });
+      completion = chatCompletion.choices[0].message.content;
+    }
+
+    console.log("Completion:", completion);
+    return NextResponse.json({ message: completion });
+  } catch (e) {
+    console.error("AI Model Request Error:", e);
+    return NextResponse.json({ 
+        error: "AI model request failed. Check the server logs for details.", 
+        details: e.message 
+    }, { status: 500 });
   }
-  catch(e){
-    console.log(e);
-    return NextResponse.json(e)
-  }
-
-
 }


### PR DESCRIPTION
This PR addresses the critical bug where requests for Google models (e.g., google/gemini-pro-1.5) were mistakenly being sent to the OpenAI chat completions endpoint, resulting in a 404 Not Found error.

Key Changes Implemented:
Conditional Routing: Implemented logic to check the model name. If the model starts with "google/", the request is now routed to the newly initialized Google Generative AI SDK. Otherwise, it uses the existing openai client.

Dynamic Model Name Handling: The code now dynamically extracts the base model name (e.g., "gemini-pro-1.5" from "google/gemini-pro-1.5") for the Google SDK call, ensuring the correct model is requested.

Correct Response Parsing: Updated the Google AI response handling to use the correct property (response.text) to retrieve the generated content.

Improved Error Handling: Enhanced the try...catch block to log specific errors from the AI model request and return a 500 status with the error details.

This fix restores the core functionality of generating AI-powered interview questions when a Google model is selected