### PR TITLE
Add GitHub issue templates for better issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug Report
+about: Report an unexpected behavior or problem
+title: "[BUG]: "
+labels: ["bug"]
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+4.
+
+## Expected Behavior
+
+Describe what you expected to happen.
+
+## Actual Behavior
+
+Describe what actually happens instead.
+
+## Screenshots / Logs
+
+If applicable, add screenshots or relevant console logs.
+
+## Environment
+
+- Device: [e.g., iPhone 14, Pixel 6]
+- OS: [e.g., iOS 17, Android 14]
+- Browser: [e.g., Chrome 128, Safari]
+- App Version / Commit: [e.g., v1.2.0 or commit hash]
+
+## Additional Context
+
+Add any other context, ideas, or notes here.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,22 @@
+---
+name: Documentation Update
+about: Suggest changes or fixes to the documentation
+title: "[DOCS]: "
+labels: ["documentation"]
+---
+
+## Summary
+
+What part of the docs needs updating?
+
+## Issue or Confusion
+
+Explain what was unclear or inaccurate.
+
+## Proposed Changes
+
+Describe what should be added, removed, or reworded.
+
+## Additional Context
+
+Links, examples, or screenshots if applicable.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,26 @@
+---
+name: Enhancement / Improvement
+about: Suggest a small improvement or UI/UX enhancement
+title: "[ENHANCEMENT]: "
+labels: ["enhancement"]
+---
+
+## Description
+
+What area or feature can be improved?
+
+## Current Behavior
+
+Briefly describe how it currently behaves.
+
+## Suggested Enhancement
+
+Describe your improvement suggestion clearly.
+
+## Benefits
+
+Explain how this change improves usability, performance, or clarity.
+
+## Additional Notes
+
+(Optional) Anything else maintainers should know.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Suggest a new idea or feature for the project
+title: "[FEATURE]: "
+labels: ["enhancement"]
+---
+
+## Summary
+
+Briefly describe the feature or improvement.
+
+## Problem
+
+Explain the problem or limitation this feature would solve.
+
+## Proposed Solution
+
+Describe how you think this could work or be implemented.
+
+## Alternatives Considered
+
+Mention any alternative approaches you’ve thought about.
+
+## Additional Context
+
+Add sketches, screenshots, or external references if helpful.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,18 @@
+---
+name: ❓ Question / Help
+about: Ask a question or request guidance
+title: "[QUESTION]: "
+labels: ["question"]
+---
+
+## Question
+
+Clearly describe your question or the help you need.
+
+## What I’ve Tried
+
+Mention what steps, searches, or experiments you’ve already done.
+
+## Additional Context
+
+(Optional) Add any code snippets, screenshots, or logs.


### PR DESCRIPTION
This PR adds GitHub issue templates to help contributors provide structured, clear, and complete information when reporting bugs, suggesting features, or requesting documentation updates.  

Included templates:  
- Bug Report  
- Feature Request  
- Enhancement / Improvement  
- Documentation Update  
- Question / Help  

These templates are stored in `.github/ISSUE_TEMPLATE/` and improve issue quality, maintainability, and contributor experience.

Screenshot showing the templates working:  
<img width="1920" height="838" alt="Screenshot (308)" src="https://github.com/user-attachments/assets/4ae9a0e4-427b-4206-bc5a-ed145e8d9f13" />

<img width="1920" height="891" alt="Screenshot (309)" src="https://github.com/user-attachments/assets/e1422895-9f27-4948-9b7c-8c58042faa48" />

Closes #42 
